### PR TITLE
disconsider hyphen from subsequent line

### DIFF
--- a/src/layout.ts
+++ b/src/layout.ts
@@ -314,7 +314,7 @@ export function breakLines(
         let widthToNextBox = 0;
         let shrinkToNextBox = 0;
         let stretchToNextBox = 0;
-        for (let bp = b; bp < items.length; bp++) {
+        for (let bp = b + 1; bp < items.length; bp++) {
           const item = items[bp];
           if (item.type === 'box') {
             break;


### PR DESCRIPTION
It seems that, currently, if a line is broken at a hyphen, the width of the hyphen will (incorrectly) be added to the width that the subsequent line can fit into.

What this means is that lines immediately following a hyphenated word will occasionally have one or two characters more than what would normally fit.

This isn’t very noticeable depending on how the library is used, but for me, it meant that sometime lines following a hyphen would overflow the right margin, which made it very apparent.

I tried to fix that bug, and it appears to have worked. Hopefully it makes sense! My hope is that you can merge this pull request, and eventually release a new minor version of the library so I can be able to benefit from the change.

Thanks in advance for the attention! :tada: