### PR TITLE
Support for negative widths

### DIFF
--- a/test/html-test.ts
+++ b/test/html-test.ts
@@ -124,12 +124,14 @@ describe('html', () => {
     });
 
     it('applies hyphenation', () => {
-      const hyphenate = (s: string) => s.split('e');
+      const text = 'Content with long words that definitely needs hyphenation';
+      para.textContent = text;
 
       justifyContent(para, hyphenate);
+      assert.notEqual(para.textContent, text, 'did not insert hyphens');
 
       const lines = extractLines(para);
-      assert.deepEqual(lines, ['This is som', '-e test conte', 'nt that shoul', '-d be wrapped']);
+      assert.deepEqual(lines, ['Content with', 'long words', 'that definitely', 'needs hyphen', '-ation']);
     });
 
     it('uses correct line width if `box-sizing` is `border-box`', () => {

--- a/test/layout-test.ts
+++ b/test/layout-test.ts
@@ -275,21 +275,6 @@ describe('layout', () => {
       assert.notDeepEqual(breakpointsA, breakpointsB);
     });
 
-    it('throws if an item has negative width', () => {
-      const items = [box(-10), glue(5, 10, 10), forcedBreak()];
-      assert.throws(() => breakLines(items, 15));
-    });
-
-    it('throws if a glue item has negative shrink', () => {
-      const items = [box(10), glue(5, -10, 10), forcedBreak()];
-      assert.throws(() => breakLines(items, 15));
-    });
-
-    it('throws if a glue item has negative stretch', () => {
-      const items = [box(10), glue(5, 10, -10), forcedBreak()];
-      assert.throws(() => breakLines(items, 15));
-    });
-
     it('throws `MaxAdjustmentExceededError` if max adjustment ratio is exceeded', () => {
       const items = [box(10), glue(5, 10, 10), box(10), forcedBreak()];
       const opts = { maxAdjustmentRatio: 1 };


### PR DESCRIPTION
Hi @robertknight, thank you for this wonderful library. This PR backports support for negative widths from [egilll/ltex-linebreak2](https://github.com/egilll/tex-linebreak2) to this repository and removes the three tests that were asserting positive values. As it turns out, the "applies hyphenation" test in `html-test.ts` violates Restriction 1, but this was a very contrived example. Knuth mentions that all known practical applications meet his restrictions, so I fixed the test by making it more realistic, after which it no longer violated Restriction 1. I have not attempted to backport any tests for this feature, since @egilll's repository has diverged significantly from this one.