### PR TITLE
Update to current GitHub actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: Continuous integration
 on: pull_request
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    # Pinned to Ubuntu 22.04 to resolve a Chrome sandbox issue with Ubuntu 24.04.
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Cache the node_modules dir
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
The previous versions are deprecated and prevent CI jobs from running.