### PR TITLE
Fix optimality when negative values are in use

### DIFF
--- a/test/layout-test.ts
+++ b/test/layout-test.ts
@@ -483,6 +483,35 @@ describe('layout', () => {
       assert.deepEqual(breakpoints, [0, 3, 4]);
     });
 
+    it('does not lose the optimum when negative values are present', () => {
+      //
+      // Line-length = 10
+      //
+      //  ┌─12─┐○───────○┌─-2─┐○────○┌──9──┐○──────○
+      //   box   g(0,-2)  box   g(0)  box    g(0,+3)
+      //
+      // The best break sequence is 0-3-6:
+      //
+      //   • first line  = 12 + (-2) = 10  (perfect fit, r = 0)
+      //   • second line = 9 + stretch(3)  (r = 1/3)
+      //
+      // Without Restriction-1 guarding the optimization, the active node for the
+      // beginning of the paragraph is thrown away at breakpoint 1 (r = –∞), and the
+      // algorithm therefore ends up with 0-1-6 instead.
+      //
+      const items: InputItem[] = [
+        { type: 'box', width: 12 },
+        { type: 'glue', width: 0, stretch: 0, shrink: 2 },
+        { type: 'box', width: -2 },
+        { type: 'glue', width: 0, stretch: 0, shrink: 0 },
+        { type: 'box', width: 9 },
+        { type: 'glue', width: 0, stretch: 3, shrink: 0 },
+        forcedBreak(),
+      ];
+      const breakpoints = breakLines(items, 10);
+      assert.deepEqual(breakpoints, [0, 3, 6]);
+    });
+
     [
       {
         items: [box(10), glue(10, 10, 10), box(10), forcedBreak()],


### PR DESCRIPTION
@robertknight I spoke too soon in #103. We were fine against restriction 2, but not against restriction 1: a particular optimization relied on restriction 1. I've fixed that here by removing that optimization when restriction 1 is present. It is demonstrated in a new unit test, which fails like this before the fix to `src/layout.ts`:

```
Chrome Headless 127.0.6533.88 (Linux x86_64) layout breakLines does not lose the optimum when negative values are present FAILED
        AssertionError: expected [ +0, 1, 6 ] to deeply equal [ +0, 3, 6 ]
            at Context.<anonymous> (build/tests.bundle.js:13506:27)
```

After the fix to `src/layout.ts`, the new unit test passes. While I was here, I also added comments explaining the reasoning for why we are safe with regard to both Restrictions 1 and 2.