### PR TITLE
fix: Relax pruning to support negative widths without disabling optimization

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -2,10 +2,12 @@ import { layoutItemsFromString, layoutText, TextBox } from './helpers';
 import {
   breakLines,
   forcedBreak,
+  lineContentStart,
   InputItem,
   MaxAdjustmentExceededError,
   Box,
   Glue,
+  PARAGRAPH_START,
   Penalty,
 } from './layout';
 import { textNodesInRange } from './util/range';
@@ -23,6 +25,40 @@ type DOMBox = Box & NodeOffset;
 type DOMGlue = Glue & NodeOffset;
 type DOMPenalty = Penalty & NodeOffset;
 type DOMItem = DOMBox | DOMGlue | DOMPenalty;
+
+function setRangeStartAtItem(r: Range, item: DOMItem) {
+  if (item.node instanceof Text) {
+    r.setStart(item.node, item.start);
+    return;
+  }
+
+  const parent = item.node.parentNode;
+  if (!parent) {
+    r.setStart(item.node, item.start);
+    return;
+  }
+
+  const childIndex = Array.prototype.indexOf.call(parent.childNodes, item.node);
+  if (childIndex === -1) {
+    r.setStart(item.node, item.start);
+    return;
+  }
+
+  r.setStart(parent, childIndex);
+}
+
+function lineStartItem(items: DOMItem[], breakpoint: number, nextBreakpoint: number) {
+  const startIndex = lineContentStart(items, breakpoint, nextBreakpoint);
+  return startIndex <= nextBreakpoint ? items[startIndex] : null;
+}
+
+function isolateRangeStart(r: Range) {
+  const { startContainer, startOffset } = r;
+  if (startContainer instanceof Text && startOffset > 0 && startOffset < startContainer.length) {
+    const remainder = startContainer.splitText(startOffset);
+    r.setStart(remainder, 0);
+  }
+}
 
 /**
  * Add layout items for `node` to `items`.
@@ -207,7 +243,11 @@ function lineWidthsAndGlueCounts(items: InputItem[], breakpoints: number[]) {
     let actualWidth = 0;
     let glueCount = 0;
 
-    const start = b === 0 ? breakpoints[b] : breakpoints[b] + 1;
+    const start = lineContentStart(
+      items,
+      b === 0 ? PARAGRAPH_START : breakpoints[b],
+      breakpoints[b + 1],
+    );
     for (let p = start; p <= breakpoints[b + 1]; p++) {
       const item = items[p];
       if (item.type === 'box') {
@@ -384,19 +424,27 @@ export function justifyContent(
     // we create the Range.
     const endsWithHyphen: boolean[] = [];
     const lineRanges: Range[] = [];
+    const visibleLineWidths: number[] = [];
+    const visibleGlueCounts: number[] = [];
     for (let b = 1; b < breakpoints.length; b++) {
-      const prevBreakItem = items[breakpoints[b - 1]];
-      const breakItem = items[breakpoints[b]];
-
-      const r = document.createRange();
-      if (b > 1) {
-        r.setStart(prevBreakItem.node, prevBreakItem.end);
-      } else {
-        r.setStart(el, 0);
+      const breakpoint = breakpoints[b];
+      const startItem = lineStartItem(
+        items,
+        b > 1 ? breakpoints[b - 1] : PARAGRAPH_START,
+        breakpoint,
+      );
+      if (!startItem) {
+        continue;
       }
+
+      const breakItem = items[breakpoint];
+      const r = document.createRange();
+      setRangeStartAtItem(r, startItem);
       r.setEnd(breakItem.node, breakItem.start);
       lineRanges.push(r);
       endsWithHyphen.push(breakItem.type === 'penalty' && breakItem.flagged);
+      visibleLineWidths.push(actualWidths[b - 1]);
+      visibleGlueCounts.push(glueCounts[b - 1]);
     }
 
     // Disable automatic line wrap.
@@ -419,8 +467,10 @@ export function justifyContent(
 
     // Adjust inter-word spacing on each line and add hyphenation if needed.
     lineRanges.forEach((r, i) => {
-      const spaceDiff = lineWidth - actualWidths[i];
-      const extraSpacePerGlue = spaceDiff / glueCounts[i];
+      isolateRangeStart(r);
+
+      const spaceDiff = lineWidth - visibleLineWidths[i];
+      const extraSpacePerGlue = spaceDiff / visibleGlueCounts[i];
 
       // If this is the final line and the natural spacing between words does
       // not need to be compressed, then don't try to expand the spacing to fill

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -189,13 +189,12 @@ export function breakLines(
     throw new Error('Paragraph items must end with a forced break');
   }
 
-  const hasNegativeValues = items.some((it) => {
-    if (it.type === 'box' || it.type === 'penalty') {
-      return it.width < 0;
-    } else {
-      return it.width < 0 || it.stretch < 0 || it.shrink < 0;
-    }
-  });
+  // The pruning proof below assumes glue adjustment has the usual direction:
+  // stretch cannot reduce line width, and shrink cannot increase it.
+  const hasNegativeStretchOrShrink = items.some(
+    (item) => item.type === 'glue' && (item.stretch < 0 || item.shrink < 0),
+  );
+  const hasNegativeWidths = items.some((item) => item.width < 0);
 
   const prefixSums = items.reduce(
     (sums, item, i) => {
@@ -213,6 +212,82 @@ export function breakLines(
     },
   );
 
+  // Precompute the suffix minimum of the line-width floor
+  //
+  //   floor = boxWidthPrefix[b + 1] + glueWidthPrefix[b] - glueShrinkPrefix[b] + penaltyWidth
+  //
+  // at each feasible breakpoint. This matches the line-measurement semantics
+  // used elsewhere in the implementation:
+  //
+  //  - boxes always count;
+  //  - glue counts only when it is interior to the line;
+  //  - only the chosen breakpoint's penalty width counts.
+  //
+  // This supports the overfull-line pruning optimization described below.
+  //
+  // The classic TeX algorithm deactivates a node when the adjustment ratio
+  // r < -1, meaning the line is overfull even at maximum shrink. Knuth & Plass
+  // (p. 1161) prove this is safe when all widths, stretches, and shrinks are
+  // non-negative (Restriction 1), since this floor can then only increase
+  // at later breakpoints.
+  //
+  // We relax this by precomputing, for each breakpoint `b`, the minimum floor
+  // value over all strictly later breakpoints (including forced breaks). At
+  // breakpoint `b`, a node `a` is pruned only when even this best-case future
+  // floor exceeds the overfull threshold for `a`.
+  //
+  // The floor-to-overfull equivalence (`floor > threshold` iff `r < -1`)
+  // requires non-negative stretch and shrink on every line segment:
+  //
+  //  - Negative shrink makes lineShrink < 0, so the floor comparison no longer
+  //    implies overfull.
+  //  - Negative stretch can produce r < -1 for underfilled lines
+  //    (actualLen < idealLen with lineStretch < 0), a case the floor check does
+  //    not cover.
+  //
+  // We therefore disable the optimization entirely when any glue has negative
+  // stretch or shrink (`hasNegativeStretchOrShrink`). When this guard allows
+  // pruning, every line segment's total stretch and shrink is also
+  // non-negative, since they are sums of per-item non-negative values. Under
+  // that condition, the floor check correctly handles negative intermediate
+  // widths, negative penalty widths, and forced breaks with negative content
+  // preceding them.
+  const suffixMinBreakpointFloor = new Array<number>(items.length).fill(Infinity);
+
+  // Whether `b` is a feasible breakpoint: glue after a box, or a legal penalty.
+  // Used by both the suffix-minimum prepass and the main loop.
+  const isFeasibleBreakpoint = (b: number) => {
+    const item = items[b];
+    return (
+      (item.type === 'glue' && b > 0 && items[b - 1].type === 'box') ||
+      (item.type === 'penalty' && item.cost < MAX_COST)
+    );
+  };
+
+  if (!hasNegativeStretchOrShrink) {
+    for (let b = 0; b < items.length; b++) {
+      if (isFeasibleBreakpoint(b)) {
+        const item = items[b];
+        const penaltyWidth = item.type === 'penalty' ? item.width : 0;
+        suffixMinBreakpointFloor[b] =
+          prefixSums.boxWidth[b + 1] +
+          prefixSums.glueWidth[b] -
+          prefixSums.glueShrink[b] +
+          penaltyWidth;
+      }
+    }
+
+    // Backward pass: suffix minimum floor over strictly later breakpoints.
+    let minFloor = Infinity;
+    for (let i = items.length - 1; i >= 0; i--) {
+      const floor = suffixMinBreakpointFloor[i];
+      if (floor !== Infinity) {
+        suffixMinBreakpointFloor[i] = minFloor;
+        minFloor = Math.min(minFloor, floor);
+      }
+    }
+  }
+
   const opts_ = { ...defaultOptions, ...opts };
   const lineLen = (i: number) => (Array.isArray(lineLengths) ? lineLengths[i] : lineLengths);
   const currentMaxAdjustmentRatio = Math.min(
@@ -224,6 +299,9 @@ export function breakLines(
     index: number; // Index in `items`.
     line: number; // Line number.
     fitness: number;
+    // Whether this node was created by the bailout path rather than a
+    // feasible breakpoint.
+    isFallback: boolean;
     // Minimum sum of demerits up this break.
     totalDemerits: number;
     prev: null | Node;
@@ -246,6 +324,7 @@ export function breakLines(
     line: 0,
     // Fitness is ignored for this node.
     fitness: 0,
+    isFallback: false,
     totalDemerits: 0,
     prev: null,
   });
@@ -281,7 +360,7 @@ export function breakLines(
     const start = Math.min(rawStart, endBreakpoint + 1);
 
     if (start > endBreakpoint) {
-      return { actualLen: 0, lineStretch: 0, lineShrink: 0 };
+      return { actualLen: 0, lineStretch: 0, lineShrink: 0, startOffset: 0 };
     }
 
     const interiorGlueStart = Math.min(start + 1, endBreakpoint);
@@ -296,6 +375,8 @@ export function breakLines(
       lineStretch:
         prefixSums.glueStretch[endBreakpoint] - prefixSums.glueStretch[interiorGlueStart],
       lineShrink: prefixSums.glueShrink[endBreakpoint] - prefixSums.glueShrink[interiorGlueStart],
+      startOffset:
+        prefixSums.boxWidth[start] + prefixSums.glueWidth[start] - prefixSums.glueShrink[start],
     };
   };
 
@@ -305,10 +386,7 @@ export function breakLines(
     const item = items[b];
 
     // Determine if this is a feasible breakpoint.
-    const canBreak =
-      (item.type === 'glue' && b > 0 && items[b - 1].type === 'box') ||
-      (item.type === 'penalty' && item.cost < MAX_COST);
-    if (!canBreak) {
+    if (!isFeasibleBreakpoint(b)) {
       continue;
     }
 
@@ -320,7 +398,7 @@ export function breakLines(
       // Compute adjustment ratio from `a` to `b`.
       let adjustmentRatio = 0;
       const idealLen = lineLen(a.line);
-      const { actualLen, lineStretch, lineShrink } = lineMetrics(a.index, b);
+      const { actualLen, lineStretch, lineShrink, startOffset } = lineMetrics(a.index, b);
 
       if (actualLen < idealLen) {
         adjustmentRatio = (idealLen - actualLen) / lineStretch;
@@ -339,24 +417,45 @@ export function breakLines(
         );
       }
 
-      // The optimization that removes an active node when $r < –1$ is safe only if
-      // all widths, stretches, and shrinks are non–negative, as explained on p.
-      // 1161:
+      // Pruning: deactivate nodes whose lines are irrecoverably overfull.
       //
-      //   "Note that Restriction 1 makes it legitimate to deactivate a node when
-      //    we discover that $r < -1$, since $r < -1$ is equivalent to $l_l < L_{ab}
-      //    - Z_{ab}$, therefore subsequent breakpoints $b' > b$ will have $L_{ab'}
-      //    - Z_{ab'} >= L_{ab} - Z_{ab}$. Thus it is not difficult to verify that
-      //    the algorithm does indeed find an optimal solution: Given any sequence
-      //    of feasible breakpoints $b_1 < ... < b_k$, we can prove by induction on
-      //    $j$ that the algorithm constructs a node for a feasible break at $j$,
-      //    with appropriate line numbers and fitness classifications, having no
-      //    more demerits than the given sequence does."
+      // Four conditions must hold (besides the forced-break case):
       //
-      // Therefore, we deactivate an active node in the usual TeX way only when the
-      // paragraph satisfies Restriction 1 (i.e., no negative values). Forced breaks
-      // are always allowed to prune the list.
-      if ((!hasNegativeValues && adjustmentRatio < MIN_ADJUSTMENT_RATIO) || isForcedBreak(item)) {
+      // 1. `!hasNegativeStretchOrShrink`: negative glue stretch or shrink
+      //    breaks the floor-to-overfull equivalence (see the prepass comment
+      //    above), so we disable pruning entirely in that case. This is a
+      //    paragraph-wide guard, not a per-line check.
+      //
+      // 2. `!a.isFallback || !hasNegativeWidths`: synthetic fallback nodes are
+      //    created after the algorithm gives up on finding a feasible break.
+      //    With negative widths present, a later breakpoint can still reduce
+      //    the line-width floor relative to such a node, so we avoid applying
+      //    this pruning rule to fallback nodes in that case.
+      //
+      // 3. `adjustmentRatio < -1`: the current line from `a` to `b` is
+      //    itself overfull. This matches the classic TeX condition once the
+      //    line-relative stretch and shrink are known to be non-negative.
+      //
+      // 4. `futureMinFloor > overfullThreshold`: all future breakpoints
+      //    would also produce overfull lines from `a`. The precomputed suffix
+      //    minimum of the line-width floor over breakpoints strictly after `b`
+      //    gives the best-case future floor in the same coordinate system as
+      //    `lineMetrics`; when it exceeds `idealLen + startOffset`, no future
+      //    breakpoint can rescue the line. Under Restriction 1 this is always
+      //    satisfied when r < -1. For inputs with negative widths or penalty
+      //    widths (but non-negative stretch/shrink), it prevents unsound
+      //    pruning when a future breakpoint could rescue the line.
+      //
+      // Forced breaks always deactivate, regardless of the adjustment ratio.
+      const overfullThreshold = idealLen + startOffset;
+      const futureMinFloor = suffixMinBreakpointFloor[b];
+      const canUsePruning = (!a.isFallback || !hasNegativeWidths) && !hasNegativeStretchOrShrink;
+      if (
+        isForcedBreak(item) ||
+        (canUsePruning &&
+          adjustmentRatio < MIN_ADJUSTMENT_RATIO &&
+          futureMinFloor > overfullThreshold)
+      ) {
         // Items from `a` to `b` cannot fit on one line.
         active.delete(a);
         lastActive = a;
@@ -404,6 +503,7 @@ export function breakLines(
           index: b,
           line: a.line + 1,
           fitness,
+          isFallback: false,
           totalDemerits: a.totalDemerits + demerits,
           prev: a,
         };
@@ -441,6 +541,7 @@ export function breakLines(
           index: b,
           line: lastActive!.line + 1,
           fitness: 1,
+          isFallback: true,
           totalDemerits: lastActive!.totalDemerits + 1000,
           prev: lastActive!,
         });

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -104,10 +104,44 @@ export const MIN_COST = -1000;
 export const MAX_COST = 1000;
 
 const MIN_ADJUSTMENT_RATIO = -1;
-const PARAGRAPH_START = -1;
+export const PARAGRAPH_START = -1;
 
 function isForcedBreak(item: InputItem) {
   return item.type === 'penalty' && item.cost <= MIN_COST;
+}
+
+function lineStartsWithContent(item: InputItem) {
+  return item.type === 'box' || (item.type === 'penalty' && item.cost >= MAX_COST);
+}
+
+function lineStartIndex(items: InputItem[], breakpoint: number) {
+  let start;
+  if (breakpoint === PARAGRAPH_START) {
+    start = 0;
+  } else {
+    // A penalty's width (e.g. a hyphen) is charged to the line that ends
+    // here, not the next line. Skip it so it doesn't inflate the next line.
+    start = breakpoint + (items[breakpoint].type === 'penalty' ? 1 : 0);
+  }
+
+  while (start < items.length && !lineStartsWithContent(items[start])) {
+    start++;
+  }
+
+  return start;
+}
+
+/**
+ * Compute the start index for the content of a line, clamped so it never
+ * exceeds `endBreakpoint + 1`. When the result equals `endBreakpoint + 1`,
+ * the line span is empty.
+ */
+export function lineContentStart(
+  items: InputItem[],
+  startBreakpoint: number,
+  endBreakpoint: number,
+): number {
+  return Math.min(lineStartIndex(items, startBreakpoint), endBreakpoint + 1);
 }
 
 const defaultOptions: Options = {
@@ -509,7 +543,11 @@ export function adjustmentRatios(
     let lineShrink = 0;
     let lineStretch = 0;
 
-    const start = b === 0 ? breakpoints[b] : breakpoints[b] + 1;
+    const start = lineContentStart(
+      items,
+      b === 0 ? PARAGRAPH_START : breakpoints[b],
+      breakpoints[b + 1],
+    );
     for (let p = start; p <= breakpoints[b + 1]; p++) {
       const item = items[p];
       if (item.type === 'box') {
@@ -564,7 +602,11 @@ export function positionItems(
     // item in a line.
     const adjustmentRatio = Math.max(adjRatios[b], MIN_ADJUSTMENT_RATIO);
     let xOffset = 0;
-    const start = b === 0 ? breakpoints[b] : breakpoints[b] + 1;
+    const start = lineContentStart(
+      items,
+      b === 0 ? PARAGRAPH_START : breakpoints[b],
+      breakpoints[b + 1],
+    );
 
     for (let p = start; p <= breakpoints[b + 1]; p++) {
       const item = items[p];

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -197,6 +197,22 @@ export function breakLines(
     }
   });
 
+  const prefixSums = items.reduce(
+    (sums, item, i) => {
+      sums.boxWidth[i + 1] = sums.boxWidth[i] + (item.type === 'box' ? item.width : 0);
+      sums.glueWidth[i + 1] = sums.glueWidth[i] + (item.type === 'glue' ? item.width : 0);
+      sums.glueStretch[i + 1] = sums.glueStretch[i] + (item.type === 'glue' ? item.stretch : 0);
+      sums.glueShrink[i + 1] = sums.glueShrink[i] + (item.type === 'glue' ? item.shrink : 0);
+      return sums;
+    },
+    {
+      boxWidth: new Array<number>(items.length + 1).fill(0),
+      glueWidth: new Array<number>(items.length + 1).fill(0),
+      glueStretch: new Array<number>(items.length + 1).fill(0),
+      glueShrink: new Array<number>(items.length + 1).fill(0),
+    },
+  );
+
   const opts_ = { ...defaultOptions, ...opts };
   const lineLen = (i: number) => (Array.isArray(lineLengths) ? lineLengths[i] : lineLengths);
   const currentMaxAdjustmentRatio = Math.min(
@@ -208,12 +224,6 @@ export function breakLines(
     index: number; // Index in `items`.
     line: number; // Line number.
     fitness: number;
-    // Sum of `width` up to first box or forced break after this break.
-    totalWidth: number;
-    // Sum of `stretch` up to first box or forced break after this break.
-    totalStretch: number;
-    // Sum of `shrink` up to first box or forced break after this break.
-    totalShrink: number;
     // Minimum sum of demerits up this break.
     totalDemerits: number;
     prev: null | Node;
@@ -221,46 +231,83 @@ export function breakLines(
 
   const active = new Set<Node>();
 
+  // nextContent[i] is the index of the first content item at or after
+  // position i (O(n) right-to-left precomputation). The sentinel at
+  // items.length means "no content found".
+  const nextContent = new Array<number>(items.length + 1);
+  nextContent[items.length] = items.length;
+  for (let i = items.length - 1; i >= 0; i--) {
+    nextContent[i] = lineStartsWithContent(items[i]) ? i : nextContent[i + 1];
+  }
+
   // Add initial active node for beginning of paragraph.
   active.add({
     index: PARAGRAPH_START,
     line: 0,
     // Fitness is ignored for this node.
     fitness: 0,
-    totalWidth: 0,
-    totalStretch: 0,
-    totalShrink: 0,
     totalDemerits: 0,
     prev: null,
   });
 
-  // Sum of `width` of items up to current item.
-  let sumWidth = 0;
-  // Sum of `stretch` of glue items up to current item.
-  let sumStretch = 0;
-  // Sum of `shrink` of glue items up to current item.
-  let sumShrink = 0;
+  // Compute the width, stretch and shrink of items in a line between two
+  // breakpoints, excluding glue and penalty items at the start of the line.
+  // When rendering we ignore such items at the start of lines.
+  //
+  // Knuth's original algorithm (TeX) keeps running sums of width / stretch /
+  // shrink from the *start* of the paragraph up to every breakpoint. The values
+  // for an individual line are then obtained simply by subtracting the two
+  // totals:
+  //
+  //      lineWidth = Sum(width[0..b]) - Sum(width[0..a])
+  //      lineStretch/shrink likewise
+  //
+  // This is only correct if there is at least one box item between the two
+  // breakpoints; otherwise the subtraction would leave out the glue and
+  // penalties that precede the first box of the new line. For efficiency TeX
+  // therefore imposes Restriction 2 (p. 1156): two legal breakpoints may not be
+  // separated solely by glue and/or ordinary penalties.
+  //
+  // Instead of enforcing Restriction 2 we use `nextContent` to find the first
+  // content item on each line, then compute metrics from that point using
+  // prefix sums. This naturally excludes leading glue and penalties, so the
+  // subtraction yields correct figures even if two successive breakpoints are
+  // separated only by glue.
+  const lineMetrics = (startBreakpoint: number, endBreakpoint: number) => {
+    const rawStart =
+      startBreakpoint === PARAGRAPH_START
+        ? nextContent[0]
+        : nextContent[startBreakpoint + (items[startBreakpoint].type === 'penalty' ? 1 : 0)];
+    const start = Math.min(rawStart, endBreakpoint + 1);
+
+    if (start > endBreakpoint) {
+      return { actualLen: 0, lineStretch: 0, lineShrink: 0 };
+    }
+
+    const interiorGlueStart = Math.min(start + 1, endBreakpoint);
+    const penaltyWidth = items[endBreakpoint].type === 'penalty' ? items[endBreakpoint].width : 0;
+
+    return {
+      actualLen:
+        prefixSums.boxWidth[endBreakpoint + 1] -
+        prefixSums.boxWidth[start] +
+        (prefixSums.glueWidth[endBreakpoint] - prefixSums.glueWidth[interiorGlueStart]) +
+        penaltyWidth,
+      lineStretch:
+        prefixSums.glueStretch[endBreakpoint] - prefixSums.glueStretch[interiorGlueStart],
+      lineShrink: prefixSums.glueShrink[endBreakpoint] - prefixSums.glueShrink[interiorGlueStart],
+    };
+  };
 
   let minAdjustmentRatioAboveThreshold = Infinity;
 
   for (let b = 0; b < items.length; b++) {
     const item = items[b];
 
-    // Determine if this is a feasible breakpoint and update `sumWidth`,
-    // `sumStretch` and `sumShrink`.
-    let canBreak = false;
-    if (item.type === 'box') {
-      sumWidth += item.width;
-    } else if (item.type === 'glue') {
-      canBreak = b > 0 && items[b - 1].type === 'box';
-      if (!canBreak) {
-        sumWidth += item.width;
-        sumShrink += item.shrink;
-        sumStretch += item.stretch;
-      }
-    } else if (item.type === 'penalty') {
-      canBreak = item.cost < MAX_COST;
-    }
+    // Determine if this is a feasible breakpoint.
+    const canBreak =
+      (item.type === 'glue' && b > 0 && items[b - 1].type === 'box') ||
+      (item.type === 'penalty' && item.cost < MAX_COST);
     if (!canBreak) {
       continue;
     }
@@ -272,15 +319,8 @@ export function breakLines(
     active.forEach((a) => {
       // Compute adjustment ratio from `a` to `b`.
       let adjustmentRatio = 0;
-      const lineShrink = sumShrink - a.totalShrink;
-      const lineStretch = sumStretch - a.totalStretch;
       const idealLen = lineLen(a.line);
-      let actualLen = sumWidth - a.totalWidth;
-
-      // Include width of penalty in line length if chosen as a breakpoint.
-      if (item.type === 'penalty') {
-        actualLen += item.width;
-      }
+      const { actualLen, lineStretch, lineShrink } = lineMetrics(a.index, b);
 
       if (actualLen < idealLen) {
         adjustmentRatio = (idealLen - actualLen) / lineStretch;
@@ -360,66 +400,10 @@ export function breakLines(
           demerits += opts_.adjacentLooseTightPenalty;
         }
 
-        // If this breakpoint is followed by glue or non-breakable penalty items
-        // then we don't want to include the width of those when calculating the
-        // width of lines starting after this breakpoint. This is because when
-        // rendering we ignore glue/penalty items at the start of lines.
-        //
-        // Knuth’s original algorithm (TeX) keeps running sums of width / stretch /
-        // shrink from the *start* of the paragraph up to every breakpoint. The
-        // values for an individual line are then obtained simply by subtracting the
-        // two totals:
-        //
-        //      lineWidth = Σwidth[b] − Σwidth[a]
-        //      lineStretch/shrink likewise
-        //
-        // This is only correct if there is at least one **box** item between the
-        // two breakpoints; otherwise the subtraction would leave out the glue and
-        // penalties that precede the first box of the new line. For efficiency TeX
-        // therefore imposes Restriction 2 (p. 1156): two legal breakpoints may not
-        // be separated solely by glue and/or ordinary penalties.
-        //
-        // Instead of enforcing Restriction 2 we take a different approach: whenever
-        // we create a node for a candidate breakpoint `b` we *look ahead* until we
-        // reach the next box (or an unbreakable penalty) and add the intervening
-        // width/stretch/shrink to the node’s accumulated totals. Hence
-        //
-        //      node.totalWidth   = Σwidth up to the first box of the next line
-        //      node.totalStretch = …
-        //      node.totalShrink  = …
-        //
-        // With these augmented totals the simple subtraction still yields the correct
-        // figures even if two successive breakpoints are separated only by glue.
-        // The price is a tiny extra scan per node, which is acceptable for the sizes
-        // we deal with here and keeps the rest of the algorithm (and the input it can
-        // accept) simple.
-        let widthToNextBox = 0;
-        let shrinkToNextBox = 0;
-        let stretchToNextBox = 0;
-        // A penalty's width (e.g. a hyphen) is charged to the line that ends
-        // here, not the next line. Skip it so it doesn't inflate the totals.
-        for (let bp = b + (item.type === 'penalty' ? 1 : 0); bp < items.length; bp++) {
-          const item = items[bp];
-          if (item.type === 'box') {
-            break;
-          }
-          if (item.type === 'penalty' && item.cost >= MAX_COST) {
-            break;
-          }
-          widthToNextBox += item.width;
-          if (item.type === 'glue') {
-            shrinkToNextBox += item.shrink;
-            stretchToNextBox += item.stretch;
-          }
-        }
-
         const node = {
           index: b,
           line: a.line + 1,
           fitness,
-          totalWidth: sumWidth + widthToNextBox,
-          totalShrink: sumShrink + shrinkToNextBox,
-          totalStretch: sumStretch + stretchToNextBox,
           totalDemerits: a.totalDemerits + demerits,
           prev: a,
         };
@@ -457,19 +441,10 @@ export function breakLines(
           index: b,
           line: lastActive!.line + 1,
           fitness: 1,
-          totalWidth: sumWidth,
-          totalShrink: sumShrink,
-          totalStretch: sumStretch,
           totalDemerits: lastActive!.totalDemerits + 1000,
           prev: lastActive!,
         });
       }
-    }
-
-    if (item.type === 'glue') {
-      sumWidth += item.width;
-      sumStretch += item.stretch;
-      sumShrink += item.shrink;
     }
   }
 

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -104,6 +104,7 @@ export const MIN_COST = -1000;
 export const MAX_COST = 1000;
 
 const MIN_ADJUSTMENT_RATIO = -1;
+const PARAGRAPH_START = -1;
 
 function isForcedBreak(item: InputItem) {
   return item.type === 'penalty' && item.cost <= MIN_COST;
@@ -188,7 +189,7 @@ export function breakLines(
 
   // Add initial active node for beginning of paragraph.
   active.add({
-    index: 0,
+    index: PARAGRAPH_START,
     line: 0,
     // Fitness is ignored for this node.
     fitness: 0,
@@ -302,8 +303,8 @@ export function breakLines(
         }
 
         let doubleHyphenPenalty = 0;
-        const prevItem = items[a.index];
-        if (item.type === 'penalty' && prevItem.type === 'penalty') {
+        const prevItem = a.index === PARAGRAPH_START ? null : items[a.index];
+        if (item.type === 'penalty' && prevItem?.type === 'penalty') {
           if (item.flagged && prevItem.flagged) {
             doubleHyphenPenalty = opts_.doubleHyphenPenalty;
           }
@@ -321,7 +322,7 @@ export function breakLines(
         } else {
           fitness = 3;
         }
-        if (a.index > 0 && Math.abs(fitness - a.fitness) > 1) {
+        if (a.index !== PARAGRAPH_START && Math.abs(fitness - a.fitness) > 1) {
           demerits += opts_.adjacentLooseTightPenalty;
         }
 
@@ -458,7 +459,7 @@ export function breakLines(
   const output = [];
   let next: Node | null = bestNode!;
   while (next) {
-    output.push(next.index);
+    output.push(next.index === PARAGRAPH_START ? 0 : next.index);
     next = next.prev;
   }
   output.reverse();

--- a/test/html-test.ts
+++ b/test/html-test.ts
@@ -80,6 +80,15 @@ describe('html', () => {
       });
     });
 
+    it('does not stretch leading whitespace skipped at the start of a line', () => {
+      para.textContent = '   This is some test content that should be wrapped';
+
+      justifyContent(para);
+
+      const firstSpan = para.querySelector('span')!;
+      assert.isFalse(firstSpan.textContent!.startsWith(' '));
+    });
+
     it("disables the browser's own line wrapping", () => {
       justifyContent(para);
       assert.equal(para.style.whiteSpace, 'nowrap');
@@ -120,7 +129,9 @@ describe('html', () => {
       justifyContent(para);
       stripSpacing(para);
 
-      assert.equal(para.innerHTML, '<span style="">This is </span><b><span style="">some </span><br><span style="">text</span></b><span style=""> with </span><br><i>various styles</i>');
+      assert.deepEqual(extractLines(para), ['This is some', 'text with', 'various styles']);
+      assert.equal(para.querySelector('b')!.textContent, 'some text');
+      assert.equal(para.querySelector('i')!.textContent, 'various styles');
     });
 
     it('applies hyphenation', () => {

--- a/test/layout-test.ts
+++ b/test/layout-test.ts
@@ -513,6 +513,39 @@ describe('layout', () => {
       assert.deepEqual(breakpoints, [0, 3, 6]);
     });
 
+    it('ignores repeated leading glue after a breakpoint', () => {
+      const items: InputItem[] = [
+        box(5),
+        penalty(0, 0, false),
+        glue(10, 0, 0),
+        glue(-10, 0, 0),
+        box(5),
+        forcedBreak(),
+      ];
+      const breakpoints = breakLines(items, 5);
+      assert.deepEqual(breakpoints, [0, 1, 5]);
+      assert.deepEqual(adjustmentRatios(items, 5, breakpoints), [0, 0]);
+      assert.deepEqual(positionItems(items, 5, breakpoints), [
+        { item: 0, line: 0, xOffset: 0, width: 5 },
+        { item: 4, line: 1, xOffset: 0, width: 5 },
+      ]);
+    });
+
+    it('ignores leading penalty and glue at the start of the paragraph', () => {
+      const items: InputItem[] = [
+        penalty(0, 0, false),
+        glue(5, 0, 0),
+        box(5),
+        forcedBreak(),
+      ];
+      const breakpoints = breakLines(items, 5);
+      assert.deepEqual(breakpoints, [0, 3]);
+      assert.deepEqual(adjustmentRatios(items, 5, breakpoints), [0]);
+      assert.deepEqual(positionItems(items, 5, breakpoints), [
+        { item: 2, line: 0, xOffset: 0, width: 5 },
+      ]);
+    });
+
     [
       {
         items: [box(10), glue(10, 10, 10), box(10), forcedBreak()],

--- a/test/layout-test.ts
+++ b/test/layout-test.ts
@@ -5,6 +5,8 @@ import {
   adjustmentRatios,
   breakLines,
   forcedBreak,
+  MAX_COST,
+  MIN_COST,
   positionItems,
   Box,
   Glue,
@@ -544,6 +546,193 @@ describe('layout', () => {
       assert.deepEqual(positionItems(items, 5, breakpoints), [
         { item: 2, line: 0, xOffset: 0, width: 5 },
       ]);
+    });
+
+    it(
+      'changes behavior when negative glue cannot rescue a later line',
+      () => {
+        // Under the old `hasNegativeValues` guard, the negative glue width
+        // disabled pruning and the algorithm fell back to [0, 4]. The new
+        // rule still prunes this irrecoverably overfull node and isolates the
+        // wide box at [0, 3, 4].
+        const items: InputItem[] = [
+          box(5),
+          glue(-1, 0, 0),
+          box(100),
+          glue(10, 10, 10),
+          forcedBreak(),
+        ];
+        const breakpoints = breakLines(items, 50);
+        assert.deepEqual(breakpoints, [0, 3, 4]);
+      },
+    );
+
+    it('does not keep splitting a negative-width fallback segment', () => {
+      // The first bailout at index 1 is intentional: the opening box is
+      // irrecoverably overfull. After that synthetic fallback node is created,
+      // pruning should not keep inserting more bailout breaks inside the same
+      // negative-width tail.
+      const items: InputItem[] = [
+        box(9),
+        glue(1, 4, 4),
+        glue(-1, 1, 4),
+        box(6),
+        box(6),
+        glue(-3, 2, 3),
+        glue(1, 4, 4),
+        box(-3),
+        penalty(2, 5, false),
+        box(9),
+        box(5),
+        penalty(2, 40, false),
+        glue(1, 1, 4),
+        forcedBreak(),
+      ];
+      const breakpoints = breakLines(items, 5, {
+        initialMaxAdjustmentRatio: 10,
+        maxAdjustmentRatio: null,
+      });
+      assert.deepEqual(breakpoints, [0, 1, 13]);
+    });
+
+    it(
+      'keeps the optimal breaks when negative penalty width rescues a line',
+      () => {
+        // line 0->3: box(11) + box(1) + penalty_width(-2) = 10   r = 0
+        // line 3->6: box(10) + glue(0, stretch=1000)             r \approx 0
+        //
+        // At breakpoint 1 (penalty(0)), the line from node 0 is
+        // box(11) = 11 > lineWidth(10) with zero shrink, giving r = -inf. A
+        // naive pruning rule would discard node 0 here. But the later
+        // breakpoint at penalty(-2) rescues the line: base width 12 plus
+        // penalty width -2 = 10. The suffix-minimum guard must keep node 0
+        // alive.
+        const items: InputItem[] = [
+          box(11),
+          penalty(0, 0, false),
+          box(1),
+          penalty(-2, 0, false),
+          box(10),
+          glue(0, 0, 1000),
+          forcedBreak(),
+        ];
+        const breakpoints = breakLines(items, 10);
+        assert.deepEqual(breakpoints, [0, 3, 6]);
+      },
+    );
+
+    it(
+      'keeps the optimal breaks when interior negative glue rescues a line',
+      () => {
+        // At breakpoint 1, the line from node 0 is overfull: box(11) > 10.
+        // A later ordinary breakpoint is still viable because the interior
+        // glue(-4) and box(3) bring the total back to 10.
+        const items: InputItem[] = [
+          box(11),
+          penalty(0, 0, false),
+          glue(-4, 0, 0),
+          box(3),
+          penalty(0, 0, false),
+          box(10),
+          forcedBreak(),
+        ];
+        const breakpoints = breakLines(items, 10);
+        assert.deepEqual(breakpoints, [0, 4, 6]);
+      },
+    );
+
+    it(
+      'keeps the optimal breaks when pre-break negative content rescues a line',
+      () => {
+        // box(11) + glue(-2) = 9 at the forced break -> single line [0, 3].
+        // At penalty(0) (index 1), the line width is 11 > 10, but the
+        // negative glue before the forced break brings it to 9 < 10.
+        const items: InputItem[] = [
+          box(11),
+          penalty(0, 0, false),
+          glue(-2, 0, 0),
+          forcedBreak(),
+        ];
+        const breakpoints = breakLines(items, 10);
+        assert.deepEqual(breakpoints, [0, 3]);
+      },
+    );
+
+    it(
+      'does not prune when a forced break has a negative penalty width',
+      () => {
+        // box(11) + box(1) + penalty_width(-2) = 10 at the forced break.
+        // At penalty(0) (index 1), the line width is 11 > 10, but the
+        // forced break's negative width makes the line exactly 10.
+        const items: InputItem[] = [
+          box(11),
+          penalty(0, 0, false),
+          box(1),
+          penalty(-2, MIN_COST, false),
+        ];
+        const breakpoints = breakLines(items, 10);
+        assert.deepEqual(breakpoints, [0, 3]);
+      },
+    );
+
+    it('does not prune when glue shrink is negative', () => {
+      // The suffix-minimum floor argument assumes shrink cannot increase line
+      // width. Negative shrink breaks that assumption, so pruning must be
+      // disabled even when widths and stretch are otherwise ordinary.
+      //
+      // With pruning disabled, the valid solution is a single line [0, 6].
+      // If pruning were enabled, node 0 would be discarded at breakpoint 1
+      // and the algorithm would fall back to [0, 1, 6].
+      const items: InputItem[] = [
+        box(2),
+        penalty(0, 0, false),
+        glue(0, -5, 0),
+        box(0),
+        penalty(0, 0, false),
+        glue(0, 0, 0),
+        forcedBreak(),
+      ];
+      const breakpoints = breakLines(items, 1);
+      assert.deepEqual(breakpoints, [0, 6]);
+    });
+
+    it('does not prune when the suffix-floor proof assumptions do not hold', () => {
+      // In this case a later negative-width glue can still rescue the line, so
+      // pruning at the earlier breakpoint would discard the valid path
+      // [0, 1, 5].
+      const items: InputItem[] = [
+        box(7),
+        penalty(3, 54, false),
+        penalty(-3, 26, false),
+        glue(-6, 0, 1),
+        box(11),
+        forcedBreak(),
+      ];
+      const breakpoints = breakLines(items, [10, 10, 11], {
+        initialMaxAdjustmentRatio: 20,
+      });
+      assert.deepEqual(breakpoints, [0, 1, 5]);
+    });
+
+    it('does not prune when a later legal penalty can still rescue the line', () => {
+      // A later legal penalty contributes negative width before the forced
+      // break. Pruning at the earlier breakpoint would incorrectly discard the
+      // valid path [0, 1, 8].
+      const items: InputItem[] = [
+        box(11),
+        glue(3, 1, 0),
+        penalty(-4, 42, false),
+        { type: 'penalty', width: -3, cost: MAX_COST, flagged: false },
+        glue(2, 0, 1),
+        { type: 'penalty', width: -2, cost: MAX_COST, flagged: false },
+        box(2),
+        glue(3, 4, 3),
+        penalty(-2, MIN_COST, false),
+      ];
+      const breakpoints = breakLines(items, [11, 4, 3], {
+        initialMaxAdjustmentRatio: 20,
+      });
+      assert.deepEqual(breakpoints, [0, 1, 8]);
     });
 
     [

--- a/test/layout-test.ts
+++ b/test/layout-test.ts
@@ -693,6 +693,39 @@ describe('layout', () => {
       assert.deepEqual(breakLines(items, 12), [0, 5, 8]);
     });
 
+    it('does not charge penalty width for an empty span between consecutive penalties', () => {
+      // When two consecutive feasible breakpoints are both penalties with only
+      // glue between them, lineStartIndex advances past the second penalty,
+      // making the span empty. lineMetrics must not add the penalty width for
+      // that empty line, matching what adjustmentRatios/positionItems compute.
+      const items = [
+        box(5),
+        penalty(0, 0, false), // breakpoint 1
+        glue(1, 1, 1),
+        penalty(3, 0, false), // breakpoint 3: nonzero penalty width
+        box(5),
+        glue(1, 1, 1),
+        forcedBreak(),
+      ];
+
+      const breakpoints = breakLines(items, 10, { maxAdjustmentRatio: null });
+      const ratios = adjustmentRatios(items, 10, breakpoints);
+
+      // Every ratio must be finite: an empty line with phantom penalty width
+      // would produce a huge positive ratio because the "actual" width (just
+      // the penalty) is much less than the line length.
+      for (const r of ratios) {
+        assert.ok(Number.isFinite(r), `expected finite ratio, got ${r}`);
+      }
+    });
+
+    it('treats an exact-fit line with rigid glue as having zero adjustment', () => {
+      const items = [box(10), glue(5, 0, 0), box(10), forcedBreak()];
+      const breakpoints = breakLines(items, 25);
+
+      assert.deepEqual(breakpoints, [0, 3]);
+      assert.deepEqual(adjustmentRatios(items, 25, breakpoints), [0]);
+    });
     it('requires a terminal forced break', () => {
       const items = [box(10), glue(5, 1, 1), box(10)];
 


### PR DESCRIPTION
## Problem

The Knuth-Plass algorithm prunes active nodes when the adjustment ratio $r < -1$, meaning the line is overfull even at maximum shrink. Knuth & Plass (p. 1161) prove this is safe under Restriction 1: all widths, stretches, and shrinks are non-negative, since the line-width floor can then only increase at later breakpoints.

The previous implementation handled negative values with a blanket guard (`hasNegativeValues`): if any item had a negative width, stretch, or shrink, pruning was disabled entirely. This was correct but too conservative. For inputs with negative widths but non-negative stretch and shrink (such as music-layout use cases where cancellation terms produce negative box or glue widths) the algorithm fell back to exhaustive search, missing opportunities to prune irrecoverably overfull nodes and potentially choosing worse breakpoints.

## Solution

Replace the blanket `hasNegativeValues` guard with a suffix-minimum floor check that relaxes Knuth's Restriction 1 for negative widths while preserving it for negative stretch and shrink.

### The idea

Instead of asking, "Are all values non-negative?", we ask: "Could any future breakpoint still rescue this line?"

To answer that, it helps to track a line-width "floor." At a breakpoint, the floor is the smallest width that the line could possibly have if we spent all available shrink up to that breakpoint. If even that floor is still too large, the line is irrecoverably overfull. If some later breakpoint has a low enough floor, we must keep the active node alive because that later breakpoint might still fit.

For a fixed active node at the start of the paragraph and line length 10, the idea looks like this:

| Quantity                 | $b_1$ |        $b_2$ |    $b_3$ |
| ------------------------ | ----: | -----------: | -------: |
| Current content          |    11 | $11 + 1 - 2$ |       20 |
| Floor $F(b)$             |    11 |           10 |       20 |
| Suffix minimum after $b$ |    10 |           20 | $\infty$ |

- At $b_1$ the current line is overfull, but the suffix minimum to the right is 10, so a later breakpoint can still rescue it.
The node must remain active.
- At $b_2$ the floor is exactly 10, so the later breakpoint fits.
- At $b_3$ the suffix minimum is $\infty$ because there is no later breakpoint.
Nothing can rescue the line after $b_3$.

$\TeX$'s original argument (p. 1161) says that, under Restriction 1, the floor can only increase as we move rightward.
We replace that monotonicity claim with a direct check of the best floor that occurs anywhere to the right.

### The relaxation

Let:

- $W(b)$ be the prefix width up to breakpoint $b$, including the penalty width if $b$ is a penalty;
- $S(b)$ be the prefix shrink up to breakpoint $b$;
- $F(b) = W(b) - S(b)$ be the breakpoint floor.

Now fix an active node $a$ and line length $L$. The line from $a$ to breakpoint $b$ has

$$W_a(b) = W(b) - a.\text{totalWidth}$$

and

$$S_a(b) = S(b) - a.\text{totalShrink}.$$

Its floor is therefore

$$F_a(b) = W_a(b) - S_a(b) = F(b) - a.\text{totalWidth} + a.\text{totalShrink}.$$

The line is irrecoverably overfull exactly when its floor exceeds the target line length:

$$F_a(b) > L.$$

Rearranging gives a threshold in prefix coordinates:

$$F(b) > L + a.\text{totalWidth} - a.\text{totalShrink}.$$

Here $r(a,b)$ denotes the adjustment ratio of the line from active node $a$ to breakpoint $b$. The pruning rule becomes:

1. The current breakpoint $b$ must itself satisfy $r(a,b) < -1$.
2. The minimum floor over all strictly later breakpoints must still exceed

$$L + a.\text{totalWidth} - a.\text{totalShrink}.$$

If both conditions hold, no later breakpoint can rescue the line from $a$.

### Proof

The proof is short.

Suppose there exists some later breakpoint $c > b$ with

$$F(c) \le L + a.\text{totalWidth} - a.\text{totalShrink}.$$

Then

$$F_a(c) = F(c) - a.\text{totalWidth} + a.\text{totalShrink} \le L,$$

so the line from $a$ to $c$ is not overfull after maximum shrink. Therefore $a$ must remain active.

Conversely, if every later breakpoint $c > b$ satisfies

$$F(c) > L + a.\text{totalWidth} - a.\text{totalShrink},$$

then every later segment floor satisfies $F_a(c) > L$, so every such line remains overfull. In that case no future breakpoint can rescue $a$, and pruning is safe.

This is exactly what the implementation computes: the suffix minimum of $F(b)$ over strictly later breakpoints, followed by a comparison with the node-dependent threshold.

### What can go wrong

This argument relies on the usual direction of adjustment: shrink can only make a line narrower, and stretch can only make a line wider. If either sign flips, the floor argument breaks.

#### Negative shrink

Take a line of target width 1 with actual width 2 and total shrink -5. Then

$$F = \text{actual} - \text{shrink} = 2 - (-5) = 7,$$

which looks wildly overfull from the floor alone. But the adjustment ratio computed by the algorithm is

$$r = \frac{1 - 2}{-5} = 0.2,$$

which lies in the feasible range. The problem is that negative shrink no longer moves width downward.
Subtracting shrink makes the floor larger, not smaller, so the floor is no longer a lower bound on the final line width. This is why the optimization is disabled whenever any glue has negative shrink.

#### Negative stretch

Now take a line of target width 10 with actual width 8 and total stretch -1. The line is underfull, not overfull, but the adjustment ratio is

$$r = \frac{10 - 8}{-1} = -2.$$

So $r < -1$ can occur even though the line is short, not long. Meanwhile the floor is just

$$F = 8,$$

which is below the target width 10.

This breaks the key equivalence used by $\TeX$'s pruning argument (p. 1161): $r < -1$ no longer means "overfull even at maximum shrink." Negative stretch makes the adjustment ratio itself change meaning, so the pruning test cannot even get started. For that reason the implementation also disables the optimization whenever any glue has negative stretch.

## Implementation

The relaxation adds a small $O(n)$ precomputation ahead of the usual dynamic-programming pass:

1. A forward pass walks the paragraph once and records the floor

   $$F(b) = \text{sumWidth} + \text{penaltyWidth} - \text{sumShrink}$$

   at each feasible breakpoint.

2. A backward pass computes the suffix minimum of those floor values over strictly later breakpoints.

During the main search, the pruning rule becomes:

- keep the classic $\TeX$ check $r < -1$ for the current breakpoint;
- prune only if the suffix-minimum floor is still above the active node's overfull threshold;
- disable the optimization entirely if any glue has negative stretch or negative shrink;
- additionally, skip pruning for synthetic fallback nodes (created by the bailout path when no feasible break exists) when the paragraph contains negative widths, since the floor at a fallback's position may not reflect the best-case future for that node.

This preserves the original asymptotic complexity. The extra work is linear in the number of items and requires one additional array of size $O(n)$.

Forced breaks always deactivate, regardless of the adjustment ratio, as required by the algorithm (p. 1157).

## Testing

Nine new test cases cover the rescue scenarios, the disqualifying cases, and fallback-node handling:

- "changes behavior when negative glue cannot rescue a later line": verifies that the new rule still prunes an irrecoverably overfull node that the old blanket guard would have kept alive, producing breakpoints `[0, 3, 4]` instead of the old `[0, 4]`.

- "does not keep splitting a negative-width fallback segment": after a synthetic fallback node is created for an irrecoverably overfull opening box, pruning must not keep inserting additional bailout breaks inside the remaining negative-width tail. Exercises the `isFallback` guard.

- "keeps the optimal breaks when negative penalty width rescues a line": a penalty with width -2 at a later breakpoint brings an overfull line back to exactly the target width; the suffix-minimum guard prevents premature pruning.

- "keeps the optimal breaks when interior negative glue rescues a line": interior `glue(-4)` followed by `box(3)` brings an overfull line back to the target width at a later breakpoint.

- "keeps the optimal breaks when pre-break negative content rescues a line": negative glue before a forced break rescues what looked overfull at an earlier breakpoint.

- "does not prune when a forced break has a negative penalty width": a forced break with `penalty(-2, MIN_COST, false)` makes the line exactly fit.

- "does not prune when glue shrink is negative": confirms that the optimization is fully disabled when any glue has negative shrink, since negative shrink breaks the floor-to-overfull equivalence.

- "does not prune when the suffix-floor proof assumptions do not hold": a later negative-width glue can still rescue the line, so pruning at the earlier breakpoint would discard the valid path.

- "does not prune when a later legal penalty can still rescue the line": a later legal penalty contributes negative width before a forced break; pruning at the earlier breakpoint would incorrectly discard the valid path.

- Existing "does not lose the optimum when negative values are present" test continues to pass with the new rule.

All existing tests pass.